### PR TITLE
Prevent default error handler override

### DIFF
--- a/!BugGrabber/!BugGrabber.toc
+++ b/!BugGrabber/!BugGrabber.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: BugGrabber
 ## Title-koKR: |CFF99FF99B|CFFFFFFFFug|CFF99FF99G|CFFFFFFFFrabber
-## Version: 2.1.0
+## Version: 2.1.1
 ## Notes: Grabs bugs for the bug sack.
 ## Author: Fritti, Rabbit
 ## X-Credits: Rowne, Ramble, kergoth, ckknight

--- a/!BugGrabber/BugGrabber.lua
+++ b/!BugGrabber/BugGrabber.lua
@@ -370,10 +370,12 @@ end
 -- Save the old handlers in case someone wants to restore them
 BugGrabber.oldset = ScriptErrors_Message.SetText
 BugGrabber.oldshow = ScriptErrors.Show
+BugGrabber.olderrorhandler = geterrorhandler()
 
 -- Set up the new handlers
 ScriptErrors_Message.SetText = BugGrabber.GrabError
 ScriptErrors.Show = function() end
+seterrorhandler = function() end
 
 -- Now register for our needed events
 f:RegisterEvent("ADDON_LOADED")


### PR DESCRIPTION
Some addons (e.g., [ShaguTweaks](https://github.com/shagu/ShaguTweaks/blob/3bbde9eb91f408d5b0499647003a5f213d2cef94/main.lua#L14)) can override the [default error handler](https://github.com/tekkub/wow-ui-source/blob/5a98d3fd8172c95966426c62cb4e8a72165a4fd5/FrameXML/BasicControls.xml#L16), which renders BugGrabber and BugSack ineffective. This change eliminates that possibility because if a user has enabled BugGrabber, they most likely want to catch errors here rather than in other addons.